### PR TITLE
Normalize working for puzzles

### DIFF
--- a/src/main/java/io/github/metal_pony/sudoku/GeneratedPuzzles.java
+++ b/src/main/java/io/github/metal_pony/sudoku/GeneratedPuzzles.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
+import io.github.metal_pony.sudoku.util.ArraysUtil;
+
 public class GeneratedPuzzles {
 
   public static List<Sudoku> convertStringsToBoards(String[] strs) {
@@ -24,6 +26,15 @@ public class GeneratedPuzzles {
     int index = rand.nextInt(PUZZLES_24_1000.length);
 
     return new String[] { PUZZLES_24_1000[index], SOLUTIONS[index] };
+  }
+
+  public static List<String> getRandomPuzzles(int amount) {
+    List<String> list = new ArrayList<>(1000);
+    for (String pStr : PUZZLES_24_1000) {
+      list.add(pStr);
+    }
+    ArraysUtil.shuffle(list);
+    return list.subList(0, amount);
   }
 
   public static final String[] SOLUTIONS = new String[] {

--- a/src/main/java/io/github/metal_pony/sudoku/Sudoku.java
+++ b/src/main/java/io/github/metal_pony/sudoku/Sudoku.java
@@ -865,16 +865,12 @@ public class Sudoku {
     }
 
     /**
-     * Creates a new Sudoku instance with data copied from <code>other</code>.
-     * @param other Another sudoku instance to copy data from.
+     * Creates a new Sudoku instance with state copied from <code>other</code>.
+     * @param other Another sudoku instance.
      */
     public Sudoku(Sudoku other) {
         this();
-        this.numEmptyCells = other.numEmptyCells;
-        this.isValid = other.isValid;
-        System.arraycopy(other.digits, 0, this.digits, 0, SPACES);
-        System.arraycopy(other.candidates, 0, this.candidates, 0, SPACES);
-        System.arraycopy(other.constraints, 0, this.constraints, 0, DIGITS);
+        copyFrom(other);
     }
 
     /**
@@ -909,16 +905,7 @@ public class Sudoku {
      */
     public Sudoku(int[] digits) {
         this();
-
-        if (digits.length != SPACES) {
-            throw new IllegalArgumentException("sudoku initialization failed: insufficient board values");
-        }
-
-        for (int ci = 0; ci < SPACES; ci++) {
-            if (digits[ci] > 0 || digits[ci] <= DIGITS) {
-                setDigit(ci, digits[ci]);
-            }
-        }
+        copyFrom(digits);
     }
 
     /** Helper that converts byte[] representation of sudoku board into int[].*/
@@ -941,6 +928,56 @@ public class Sudoku {
      */
     public Sudoku(byte[] bytes) {
         this(fromBytes(bytes));
+    }
+
+    /**
+     * Resets the instance to an empty board.
+     */
+    public void reset() {
+        this.numEmptyCells = SPACES;
+        this.isSolved = false;
+        this.isValid = true;
+        Arrays.fill(this.candidates, ALL);
+        Arrays.fill(this.digits, 0);
+        Arrays.fill(this.constraints, 0);
+    }
+
+    /**
+     * Overwrites the state of this instance with that of the one given.
+     * @param other Another Sudoku instance.
+     */
+    public void copyFrom(Sudoku other) {
+        this.numEmptyCells = other.numEmptyCells;
+        this.isSolved = other.isSolved;
+        this.isValid = other.isValid;
+        System.arraycopy(other.digits, 0, this.digits, 0, SPACES);
+        System.arraycopy(other.candidates, 0, this.candidates, 0, SPACES);
+        System.arraycopy(other.constraints, 0, this.constraints, 0, DIGITS);
+    }
+
+    /**
+     * Overwrites the state of this instance with the given sudoku array.
+     * @param digits Sudoku board digits.
+     */
+    public void copyFrom(int[] digits) {
+        if (digits.length != SPACES) {
+            throw new IllegalArgumentException("digits array has bad length");
+        }
+
+        this.numEmptyCells = SPACES;
+        this.isSolved = false;
+        this.isValid = true;
+
+        Arrays.fill(this.candidates, ALL);
+        Arrays.fill(this.digits, 0);
+        Arrays.fill(this.constraints, 0);
+
+        for (int ci = 0; ci < SPACES; ci++) {
+            int d = digits[ci];
+            if (d > 0 && d <= DIGITS) {
+                setDigit(ci, d);
+            }
+        }
     }
 
     /**

--- a/src/main/java/io/github/metal_pony/sudoku/Sudoku.java
+++ b/src/main/java/io/github/metal_pony/sudoku/Sudoku.java
@@ -2268,11 +2268,16 @@ public class Sudoku {
      * @return This sudoku.
      */
     public Sudoku normalize() {
-        for (int d = 1; d <= DIGITS; d++) {
-            int cellDigit = digits[d - 1];
-            if (cellDigit > 0 && cellDigit != d) {
-                swapDigits(cellDigit, d);
+        if (!isValid) return this;
+        if (isSolved()) {
+            copyFrom(normalize(ArraysUtil.copy(this.digits)));
+        } else {
+            if (solutionsFlag() != 1) return this;
+            int[] solutionDigits = normalize(solution().digits);
+            for (int i = 0; i < SPACES; i++) {
+                if (digits[i] == 0) solutionDigits[i] = 0;
             }
+            copyFrom(solutionDigits);
         }
         return this;
     }

--- a/src/test/java/io/github/metal_pony/sudoku/TestSudoku.java
+++ b/src/test/java/io/github/metal_pony/sudoku/TestSudoku.java
@@ -538,6 +538,99 @@ public class TestSudoku {
     }
 
     @Test
+    void test_normalize_whenInvalid_doesNothing() {
+        Sudoku invalidPuzzle = new Sudoku(invalidPuzzles[0]);
+        int[] originalDigits = invalidPuzzle.toArray();
+        Sudoku returned = invalidPuzzle.normalize();
+        assertTrue(invalidPuzzle == returned);
+        assertEquals(invalidPuzzles[0], returned.toString());
+        assertArrayEquals(originalDigits, invalidPuzzle.toArray());
+    }
+
+    @Test
+    void test_normalize_whenSolved_reordersDigits() {
+        Sudoku solution = new Sudoku(configFixture);
+        String expectedFp2 = solution.fp2();
+
+        Sudoku returned = solution.normalize();
+        assertTrue(solution == returned);
+
+        // first 9 digits are 1-9 sequential
+        int[] digits = returned.toArray();
+        for (int i = 0; i < 9; i++) {
+            assertEquals(i + 1, digits[i]);
+        }
+
+        // isFull
+        assertTrue(returned.isFull());
+        assertTrue(Sudoku.isFull(digits));
+
+        // isValid
+        assertTrue(returned.isValid());
+        assertTrue(Sudoku.isValid(digits));
+
+        // isSolved
+        // normalize() should keep constraints in sync while swapping digits on the board.
+        assertTrue(returned.isSolved());
+        assertTrue(Sudoku.isSolved(digits));
+
+        // fingerprint should not change
+        assertEquals(expectedFp2, returned.fp2());
+
+        // subsequent normalize() should have no effect
+        String returnedStr = returned.toString();
+        Sudoku extraReturned = returned.normalize();
+        assertTrue(returned == extraReturned);
+        assertEquals(returnedStr, extraReturned.toString());
+        assertArrayEquals(digits, extraReturned.toArray());
+    }
+
+    @Test
+    void test_normalize_whenMultipleSolutions_doesNothing() {
+        for(String pStr : PUZZLESTRS_TO_NUM_SOLUTIONS.keySet()) {
+            Sudoku multiSolutionPuzz = new Sudoku(pStr);
+            int[] originalDigits = multiSolutionPuzz.toArray();
+            Sudoku returned = multiSolutionPuzz.normalize();
+            assertTrue(multiSolutionPuzz == returned);
+            assertEquals(pStr, returned.toString());
+            assertArrayEquals(originalDigits, multiSolutionPuzz.toArray());
+        }
+    }
+
+    @Test
+    void test_normalize_whenSingleSolution_reordersDigits() {
+        for (String pStr : GeneratedPuzzles.getRandomPuzzles(25)) {
+            Sudoku p = new Sudoku(pStr);
+            int numEmptyCells = p.numEmptyCells();
+            int flag = p.solutionsFlag();
+            assertEquals(1, flag);
+            Sudoku solution = p.solution();
+            String fp2 = solution.fp2();
+            SudokuMask pMask = p.getMask();
+
+            Sudoku pNormal = p.normalize();
+            Sudoku solutionNormal = solution.normalize();
+            int[] pNormalDigits = pNormal.toArray();
+
+            int[] solutionNormalDigits = solutionNormal.toArray();
+            for (int i = 0; i < 9; i++) {
+                assertEquals(i + 1, solutionNormalDigits[i]);
+            }
+
+            assertEquals(solutionNormal.filterStr(pMask), pNormal.toString());
+            assertEquals(numEmptyCells, pNormal.numEmptyCells());
+            assertEquals(fp2, solutionNormal.fp2());
+            assertEquals(1, pNormal.solutionsFlag());
+            assertFalse(pNormal.isFull());
+            assertFalse(Sudoku.isFull(pNormalDigits));
+            assertTrue(pNormal.isValid());
+            assertTrue(Sudoku.isValid(pNormalDigits));
+            assertFalse(pNormal.isSolved());
+            assertFalse(Sudoku.isSolved(pNormalDigits));
+        }
+    }
+
+    @Test
     void test_searchForSolutions3_withKnownInvalidPuzzles_findsNoSolutions() {
         for (String invalidStr : invalidPuzzles) {
             Sudoku p = new Sudoku(invalidStr);


### PR DESCRIPTION
Resolves #11 

Normalize now works for puzzles.
If the grid is invalid, or does not have a single solution, normalize does nothing.
Added tests.
Constraints will be correct after normalization; the board will be reset and the new digits will be added back in, ensuring constraints are rebuilt correctly.
Tests confirm fingerprint remains the same after normalization.
(additional) Added `GeneratedPuzzles.getRandomPuzzles(int amount)` for convenience in support of tests.